### PR TITLE
Various improvements in preparation for workshops

### DIFF
--- a/src/app/dashboards/coinform.json
+++ b/src/app/dashboards/coinform.json
@@ -1,5 +1,5 @@
 ﻿{
-  "title": "COVID-19 (dis)information Dashboard v20200514",
+  "title": "COVID-19 (dis)information Dashboard v20200615",
   "services": {
     "query": {
       "idQueue": [
@@ -10,7 +10,7 @@
       ],
       "list": {
         "0": {
-          "query": "-credibility_label:\"not verifiable\"",
+          "query": "*",
           "alias": "",
           "color": "#7EB26D",
           "id": 0,
@@ -31,10 +31,12 @@
       ],
       "list": {
         "0": {
-          "from": "2019-11-16T19:36:15.000Z",
-          "to": "2020-05-14T18:36:15.000Z",
+          "from": "NOW-90DAY",
+          "to": "NOW%2B1DAY",
           "field": "publishedDate",
           "type": "time",
+          "fromDateObj": "2020-03-17T13:01:53.271Z",
+          "toDateObj": "2020-06-15T12:01:53.271Z",
           "mandate": "must",
           "active": true,
           "alias": "",
@@ -72,7 +74,7 @@
           "loadingEditor": false,
           "status": "Stable",
           "mode": "markdown",
-          "content": "# Dashboard on covid-19 (dis)information\n\nThis dashboard shows an overview of documents, mainly tweets and news articles related to corona virus and covid-19, collected and analysed by the [Co-inform](https://coinform.eu) platform. \n\nThis dashboard allows you to:\n\n* select a subset of documents by defining *filters*\n*  get an overview of how many documents have been collected over time and how many of those have been assessed to have low **credibility**\n* **explore correlations** between low credibility documents and:\n** main words in those documents\n** medical conditions mentioned in the documents\n** organizations mentioned in the documents\n** people mentioned in the documents\n* Inspect details about example documents\n\n## Main document sources \n\n* **[Twitter](https://twitter.com)**: mainly tweets with hashtags `#coronavirus`, `#covid-19`, `#bioweapon`\n* [https://www.in.gr/politics}(https://www.in.gr/politics)\n* Various news sources (not corona virus related)\n** [The Sun](https://www.thesun.co.uk)\n** [Buzzfeed](https://www.buzzfeed.com/)\n** [news.com.au](https://www.news.com.au/)\n** [Seattle Times](https://www.seattletimes.com/)\n** [Sputnik News](https://sputniknews.com/)\n** [Daily Mail](https://www.dailymail.co.uk)\n** [Daily Caller](https://dailycaller.com/)\n** many others",
+          "content": "# Dashboard on covid-19 (dis)information\n\nThis dashboard shows an overview of documents, mainly tweets and news articles related to corona virus and covid-19, collected and analysed by the [Co-inform](https://coinform.eu) platform. \n\nThis dashboard allows you to:\n\n* select a subset of documents by defining *filters*\n*  get an overview of how many documents have been collected over time and how many of those have been assessed to have low **credibility**\n* **explore correlations** between low credibility documents and:\n** main words in those documents\n** medical conditions mentioned in the documents\n** organizations mentioned in the documents\n** people mentioned in the documents\n* Inspect details about example documents\n\n## Main document sources \n\n* **[Twitter](https://twitter.com)**: mainly tweets with hashtags `#coronavirus`, `#covid-19`, `#bioweapon`\n* Various news sources (not corona virus related)\n  * [The Sun](https://www.thesun.co.uk)\n  * [Buzzfeed](https://www.buzzfeed.com/)\n  * [news.com.au](https://www.news.com.au/)\n  * [Seattle Times](https://www.seattletimes.com/)\n  * [Sputnik News](https://sputniknews.com/)\n  * [Daily Mail](https://www.dailymail.co.uk)\n  * [Daily Caller](https://dailycaller.com/)\n  * many others",
           "style": {},
           "title": "About this Dashboard",
           "show_help_message": true,
@@ -107,17 +109,16 @@
           "type": "timepicker",
           "loadingEditor": false,
           "status": "Stable",
-          "mode": "absolute",
+          "mode": "relative",
           "time_options": [
-            "15m",
             "1h",
             "24h",
             "7d",
             "30d",
-            "180d",
-            "1y"
+            "90d",
+            "180d"
           ],
-          "timespan": "180d",
+          "timespan": "90d",
           "timefield": "publishedDate",
           "timeformat": "",
           "spyable": true,
@@ -130,11 +131,7 @@
           "show_help_message": true,
           "info_mode": "markdown",
           "help_message": "Use this *timepicker* to restrict the dashboard to documents published in the selected time frame.",
-          "title": "Filter by published date",
-          "time": {
-            "from": "11/16/2019 20:36:15",
-            "to": "05/14/2020 20:36:15"
-          }
+          "title": "Filter by published date"
         },
         {
           "span": 5,
@@ -147,8 +144,8 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&wt=json",
-            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people&wt=json",
+            "basic_query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people",
             "custom": ""
           },
           "group": "default",
@@ -159,7 +156,9 @@
           "fields": [
             "categories",
             "credibility_label",
-            "source_id"
+            "source_id",
+            "organizations",
+            "people"
           ],
           "spyable": true,
           "facet_limit": 10,
@@ -173,7 +172,7 @@
           "offset": 0,
           "show_help_message": true,
           "info_mode": "markdown",
-          "help_message": "Use this component to see (and define filters for) the main;\n\n* `topics` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility labels`: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents."
+          "help_message": "Use this component to see (and define filters for) the main;\n\n* `categories` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility label`s: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents.\n* `organizations`: which have been identified as being mentioned in the text\n* `people`: who have been mentioned in the text"
         }
       ]
     },
@@ -208,7 +207,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": ""
           },
@@ -245,10 +244,10 @@
       ]
     },
     {
-      "title": "Events",
+      "title": "Overview of Rated Documents",
       "height": "150px",
       "editable": false,
-      "collapse": true,
+      "collapse": false,
       "collapsable": true,
       "panels": [
         {
@@ -261,7 +260,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": ""
           },
@@ -283,14 +282,58 @@
               "field": "id",
               "decimalDigits": 0,
               "label": "# docs matching the active filters",
-              "value": "2200566"
+              "value": "3141139"
             }
           ],
           "refresh": {
             "enable": false,
             "interval": 2
           },
-          "title": "Collected documents"
+          "title": "Collected",
+          "show_help_message": true,
+          "info_mode": "markdown",
+          "help_message": "This is the number of documents matching the *active filters* (set above)"
+        },
+        {
+          "span": 2,
+          "editable": true,
+          "type": "hits",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "basic_query": "",
+            "custom": "&fq=credibility_label:*"
+          },
+          "style": {
+            "font-size": "20pt",
+            "flex-direction": "row"
+          },
+          "arrangement": "horizontal",
+          "chart": "total",
+          "counter_pos": "above",
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "spyable": true,
+          "show_queries": true,
+          "metrics": [
+            {
+              "type": "count",
+              "field": "id",
+              "decimalDigits": 0,
+              "label": "# docs with an automated credibility rating",
+              "value": "26064"
+            }
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Rated Docs"
         },
         {
           "span": 2,
@@ -302,7 +345,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
@@ -323,8 +366,8 @@
               "type": "count",
               "field": "id",
               "decimalDigits": 0,
-              "label": "not credible",
-              "value": "527"
+              "label": "# (mostly) not credible docs",
+              "value": "11657"
             }
           ],
           "refresh": {
@@ -343,7 +386,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": "&fq=credibility_label:(\"credible\" OR \"mostly credible\")"
           },
@@ -364,8 +407,8 @@
               "type": "count",
               "field": "id",
               "decimalDigits": 0,
-              "label": "Credible docs",
-              "value": "141"
+              "label": "# (mostly) Credible docs",
+              "value": "1989"
             }
           ],
           "refresh": {
@@ -384,7 +427,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&wt=json&facet=true&facet.pivot=credibility_label&facet.limit=1000&rows=0",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label&facet.limit=1000&rows=0",
             "custom": ""
           },
           "facet_limit": 1000,
@@ -396,7 +439,7 @@
           ],
           "show_help_message": true,
           "info_mode": "markdown",
-          "help_message": "### Shows the distribution of *credibility labels* for the documents. \nThese have been **automatically** calculated using a state-of-the-art artificial intelligence system by trying to link documents with *credibility signals* such as:\n\n* **previously fact-checked claims** similar to sentences in the document\n* the **reputation of the sites** where similar sentences have been published\n\n### Understanding credibility labels\nAs part of [Co-inform](https://coinform.eu) we have defined the following set of credibility labels:\n\n* **credible**\n* **mostly credible**\n* **credibility uncertain**\n* **mostly not credible**\n* **not credible**\n\nWe also have a sixth label, which is not really about *credibility*:\n* **not verifiable** indicates that our AI had trouble assessing the credibility for some reason\n\n#### Credibility vs accuracy\nNote that our AI predicts **credibility** of a document, not **accuracy**. This is because we do not believe current AI systems are capable of assessing the accuracy of an article, only humans can do this."
+          "help_message": "### Shows the distribution of *credibility labels* for the documents. \nThese have been **automatically** calculated using a state-of-the-art artificial intelligence system by trying to link documents with *credibility signals* such as:\n\n* **previously fact-checked claims** similar to sentences in the document\n* the **reputation of the sites** where similar sentences have been published\n\n### Understanding credibility labels\nAs part of [Co-inform](https://coinform.eu) we have defined the following set of credibility labels:\n\n* **credible**\n* **mostly credible**\n* **credibility uncertain**\n* **mostly not credible**\n* **not credible**\n\nWe also have a sixth label, which is not really about *credibility*:\n\n* **not verifiable** indicates that our AI had trouble assessing the credibility for some reason\n\n#### Credibility vs accuracy\nNote that our AI predicts **credibility** of a document, not **accuracy**. This is because we do not believe current AI systems are capable of assessing the accuracy of an article, only humans can do this."
         }
       ]
     },
@@ -418,7 +461,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.range=publishedDate&facet.range.start=2019-11-16T19:36:15.000Z&facet.range.end=2020-05-14T18:36:15.000Z&facet.range.gap=%2B1DAY\n",
+            "query": "q=*&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-90DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B12HOUR\n",
             "custom": ""
           },
           "max_rows": 1000,
@@ -427,7 +470,7 @@
           "sum_value": false,
           "auto_int": true,
           "resolution": 100,
-          "interval": "1d",
+          "interval": "12h",
           "intervals": [
             "auto",
             "1s",
@@ -490,7 +533,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.range=publishedDate&facet.range.start=2019-11-16T19:36:15.000Z&facet.range.end=2020-05-14T18:36:15.000Z&facet.range.gap=%2B1DAY\n",
+            "query": "q=*&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-90DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B12HOUR\n",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "max_rows": 100000,
@@ -499,7 +542,7 @@
           "sum_value": false,
           "auto_int": true,
           "resolution": 100,
-          "interval": "1d",
+          "interval": "12h",
           "intervals": [
             "auto",
             "1s",
@@ -561,7 +604,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.field=main_elements&facet.limit=10",
+            "query": "q=*&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=main_elements&facet.limit=10",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "field": "main_elements",
@@ -583,7 +626,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&facet=true&facet.field=medical_conditions&facet.limit=10",
+            "query": "q=*&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=medical_conditions&facet.limit=10",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "field": "medical_conditions",
@@ -605,7 +648,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&wt=json&rows=0&facet=true&facet.pivot=credibility_label,organizations&facet.limit=5&facet.pivot.mincount=0",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&rows=0&facet=true&facet.pivot=credibility_label,organizations&facet.limit=5&facet.pivot.mincount=0",
             "custom": ""
           },
           "size": 0,
@@ -629,16 +672,16 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&wt=json&facet=true&facet.pivot=credibility_label,medical_conditions&f.credibility_label.facet.limit=4&f.medical_conditions.facet.limit=20&rows=0",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label,medical_conditions&f.credibility_label.facet.limit=4&f.medical_conditions.facet.limit=20&rows=0",
             "custom": ""
           },
           "facet_limit": "4,20",
-          "node_size_weight": 1,
+          "node_size_weight": 0.1,
           "link_width_weight": 1,
           "link_strength_weight": 0,
           "link_distance_weight": 0,
-          "strength": -100,
-          "colors": "#1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf",
+          "strength": -200,
+          "colors": "#693C5E, #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22",
           "mute_category_1": false,
           "mute_category_2": true,
           "spheres": true,
@@ -673,8 +716,8 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]&wt=json&rows=50",
-            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[2019-11-16T19:36:15.000Z%20TO%202020-05-14T18:36:15.000Z]",
+            "query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&rows=50",
+            "basic_query": "q=*&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]",
             "custom": "&hl=false&fq=credibility_label:*"
           },
           "size": 10,

--- a/src/app/dashboards/dev-coinform.json
+++ b/src/app/dashboards/dev-coinform.json
@@ -1,5 +1,5 @@
 ﻿{
-  "title": "Document Level Dashboard v20200514",
+  "title": "Document Level Dashboard v20200615",
   "services": {
     "query": {
       "idQueue": [
@@ -31,12 +31,12 @@
       ],
       "list": {
         "0": {
-          "from": "NOW-180DAY",
+          "from": "NOW-90DAY",
           "to": "NOW%2B1DAY",
           "field": "publishedDate",
           "type": "time",
-          "fromDateObj": "2019-11-16T19:11:01.513Z",
-          "toDateObj": "2020-05-14T18:11:01.514Z",
+          "fromDateObj": "2020-03-17T13:01:53.271Z",
+          "toDateObj": "2020-06-15T12:01:53.271Z",
           "mandate": "must",
           "active": true,
           "alias": "",
@@ -74,7 +74,7 @@
           "loadingEditor": false,
           "status": "Stable",
           "mode": "markdown",
-          "content": "# Dashboard on covid-19 (dis)information\n\nThis dashboard shows an overview of documents, mainly tweets and news articles related to corona virus and covid-19, collected and analysed by the [Co-inform](https://coinform.eu) platform. \n\nThis dashboard allows you to:\n\n* select a subset of documents by defining *filters*\n*  get an overview of how many documents have been collected over time and how many of those have been assessed to have low **credibility**\n* **explore correlations** between low credibility documents and:\n** main words in those documents\n** medical conditions mentioned in the documents\n** organizations mentioned in the documents\n** people mentioned in the documents\n* Inspect details about example documents\n\n## Main document sources \n\n* **[Twitter](https://twitter.com)**: mainly tweets with hashtags `#coronavirus`, `#covid-19`, `#bioweapon`\n* [https://www.in.gr/politics}(https://www.in.gr/politics)\n* Various news sources (not corona virus related)\n** [The Sun](https://www.thesun.co.uk)\n** [Buzzfeed](https://www.buzzfeed.com/)\n** [news.com.au](https://www.news.com.au/)\n** [Seattle Times](https://www.seattletimes.com/)\n** [Sputnik News](https://sputniknews.com/)\n** [Daily Mail](https://www.dailymail.co.uk)\n** [Daily Caller](https://dailycaller.com/)\n** many others",
+          "content": "# Dashboard on covid-19 (dis)information\n\nThis dashboard shows an overview of documents, mainly tweets and news articles related to corona virus and covid-19, collected and analysed by the [Co-inform](https://coinform.eu) platform. \n\nThis dashboard allows you to:\n\n* select a subset of documents by defining *filters*\n*  get an overview of how many documents have been collected over time and how many of those have been assessed to have low **credibility**\n* **explore correlations** between low credibility documents and:\n** main words in those documents\n** medical conditions mentioned in the documents\n** organizations mentioned in the documents\n** people mentioned in the documents\n* Inspect details about example documents\n\n## Main document sources \n\n* **[Twitter](https://twitter.com)**: mainly tweets with hashtags `#coronavirus`, `#covid-19`, `#bioweapon`\n* Various news sources (not corona virus related)\n  * [The Sun](https://www.thesun.co.uk)\n  * [Buzzfeed](https://www.buzzfeed.com/)\n  * [news.com.au](https://www.news.com.au/)\n  * [Seattle Times](https://www.seattletimes.com/)\n  * [Sputnik News](https://sputniknews.com/)\n  * [Daily Mail](https://www.dailymail.co.uk)\n  * [Daily Caller](https://dailycaller.com/)\n  * many others",
           "style": {},
           "title": "About this Dashboard",
           "show_help_message": true,
@@ -89,7 +89,7 @@
           "loadingEditor": false,
           "status": "Stable",
           "mode": "markdown",
-          "content": "## Changelog\n\n#### v20200514\n* Adding heatmap and force components to show off new `facet.pivot` queries implemented in backend\n* By default, use the `generic` collection, which contains content related to corona virus. \n\n#### v20200414\nAdded a row at the botton with an example `table` component. This is the most logical component that can be used to let the user inspect individual documents. See [issue 9 on the github repo](https://github.com/co-inform/dashboard-fe/issues/9).",
+          "content": "## Changelog\n\n#### v20200615\n* Fixed name of *Event* row\n* Filter by published date now has more useful values by default\n* Added `organizations` and `people` to the *facet filters* component\n* Tweaked values in the `force` component as the bubbles were too big now that we have around 30K rated documents\n* Added a counter for **Rated Docs** in the row of overviews and tweaked labels\n\n#### v20200514\n* Adding heatmap and force components to show off new `facet.pivot` queries implemented in backend\n* By default, use the `generic` collection, which contains content related to corona virus. \n\n#### v20200414\nAdded a row at the botton with an example `table` component. This is the most logical component that can be used to let the user inspect individual documents. See [issue 9 on the github repo](https://github.com/co-inform/dashboard-fe/issues/9).",
           "style": {},
           "title": "Development Notes"
         }
@@ -123,15 +123,14 @@
           "status": "Stable",
           "mode": "relative",
           "time_options": [
-            "15m",
             "1h",
             "24h",
             "7d",
             "30d",
-            "180d",
-            "1y"
+            "90d",
+            "180d"
           ],
-          "timespan": "180d",
+          "timespan": "90d",
           "timefield": "publishedDate",
           "timeformat": "",
           "spyable": true,
@@ -157,8 +156,8 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&wt=json",
-            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people&wt=json",
+            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people",
             "custom": ""
           },
           "group": "default",
@@ -169,7 +168,9 @@
           "fields": [
             "categories",
             "credibility_label",
-            "source_id"
+            "source_id",
+            "organizations",
+            "people"
           ],
           "spyable": true,
           "facet_limit": 10,
@@ -183,7 +184,7 @@
           "offset": 0,
           "show_help_message": true,
           "info_mode": "markdown",
-          "help_message": "Use this component to see (and define filters for) the main;\n\n* `topics` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility labels`: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents."
+          "help_message": "Use this component to see (and define filters for) the main;\n\n* `categories` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility label`s: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents.\n* `organizations`: which have been identified as being mentioned in the text\n* `people`: who have been mentioned in the text"
         }
       ]
     },
@@ -218,7 +219,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": ""
           },
@@ -240,7 +241,7 @@
               "field": "id",
               "decimalDigits": 0,
               "label": "documents matching active filters",
-              "value": "2199207"
+              "value": "3141139"
             }
           ],
           "refresh": {
@@ -255,7 +256,7 @@
       ]
     },
     {
-      "title": "Events",
+      "title": "Overview of Rated Documents",
       "height": "150px",
       "editable": true,
       "collapse": false,
@@ -271,7 +272,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": ""
           },
@@ -293,14 +294,17 @@
               "field": "id",
               "decimalDigits": 0,
               "label": "# docs matching the active filters",
-              "value": "2199207"
+              "value": "3141139"
             }
           ],
           "refresh": {
             "enable": false,
             "interval": 2
           },
-          "title": "Collected documents"
+          "title": "Collected",
+          "show_help_message": true,
+          "info_mode": "markdown",
+          "help_message": "This is the number of documents matching the *active filters* (set above)"
         },
         {
           "span": 2,
@@ -312,7 +316,48 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "basic_query": "",
+            "custom": "&fq=credibility_label:*"
+          },
+          "style": {
+            "font-size": "20pt",
+            "flex-direction": "row"
+          },
+          "arrangement": "horizontal",
+          "chart": "total",
+          "counter_pos": "above",
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "spyable": true,
+          "show_queries": true,
+          "metrics": [
+            {
+              "type": "count",
+              "field": "id",
+              "decimalDigits": 0,
+              "label": "# docs with an automated credibility rating",
+              "value": "26064"
+            }
+          ],
+          "refresh": {
+            "enable": false,
+            "interval": 2
+          },
+          "title": "Rated Docs"
+        },
+        {
+          "span": 2,
+          "editable": true,
+          "type": "hits",
+          "loadingEditor": false,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
@@ -333,15 +378,15 @@
               "type": "count",
               "field": "id",
               "decimalDigits": 0,
-              "label": "not credible",
-              "value": "527"
+              "label": "# (mostly) not credible docs",
+              "value": "11657"
             }
           ],
           "refresh": {
             "enable": false,
             "interval": 2
           },
-          "title": "Not credible docs"
+          "title": "Not credible"
         },
         {
           "span": 2,
@@ -353,7 +398,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&stats=true&stats.field=id&wt=json&rows=0\n",
             "basic_query": "",
             "custom": "&fq=credibility_label:(\"credible\" OR \"mostly credible\")"
           },
@@ -374,8 +419,8 @@
               "type": "count",
               "field": "id",
               "decimalDigits": 0,
-              "label": "Credible docs",
-              "value": "141"
+              "label": "# (mostly) Credible docs",
+              "value": "1989"
             }
           ],
           "refresh": {
@@ -394,7 +439,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label&facet.limit=1000&rows=0",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label&facet.limit=1000&rows=0",
             "custom": ""
           },
           "facet_limit": 1000,
@@ -406,7 +451,7 @@
           ],
           "show_help_message": true,
           "info_mode": "markdown",
-          "help_message": "### Shows the distribution of *credibility labels* for the documents. \nThese have been **automatically** calculated using a state-of-the-art artificial intelligence system by trying to link documents with *credibility signals* such as:\n\n* **previously fact-checked claims** similar to sentences in the document\n* the **reputation of the sites** where similar sentences have been published\n\n### Understanding credibility labels\nAs part of [Co-inform](https://coinform.eu) we have defined the following set of credibility labels:\n\n* **credible**\n* **mostly credible**\n* **credibility uncertain**\n* **mostly not credible**\n* **not credible**\n\nWe also have a sixth label, which is not really about *credibility*:\n* **not verifiable** indicates that our AI had trouble assessing the credibility for some reason\n\n#### Credibility vs accuracy\nNote that our AI predicts **credibility** of a document, not **accuracy**. This is because we do not believe current AI systems are capable of assessing the accuracy of an article, only humans can do this."
+          "help_message": "### Shows the distribution of *credibility labels* for the documents. \nThese have been **automatically** calculated using a state-of-the-art artificial intelligence system by trying to link documents with *credibility signals* such as:\n\n* **previously fact-checked claims** similar to sentences in the document\n* the **reputation of the sites** where similar sentences have been published\n\n### Understanding credibility labels\nAs part of [Co-inform](https://coinform.eu) we have defined the following set of credibility labels:\n\n* **credible**\n* **mostly credible**\n* **credibility uncertain**\n* **mostly not credible**\n* **not credible**\n\nWe also have a sixth label, which is not really about *credibility*:\n\n* **not verifiable** indicates that our AI had trouble assessing the credibility for some reason\n\n#### Credibility vs accuracy\nNote that our AI predicts **credibility** of a document, not **accuracy**. This is because we do not believe current AI systems are capable of assessing the accuracy of an article, only humans can do this."
         }
       ]
     },
@@ -428,7 +473,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-180DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B1DAY\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-90DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B12HOUR\n",
             "custom": ""
           },
           "max_rows": 1000,
@@ -437,7 +482,7 @@
           "sum_value": false,
           "auto_int": true,
           "resolution": 100,
-          "interval": "1d",
+          "interval": "12h",
           "intervals": [
             "auto",
             "1s",
@@ -500,7 +545,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-180DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B1DAY\n",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.range=publishedDate&facet.range.start=NOW-90DAY&facet.range.end=NOW%2B1DAY&facet.range.gap=%2B12HOUR\n",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "max_rows": 100000,
@@ -509,7 +554,7 @@
           "sum_value": false,
           "auto_int": true,
           "resolution": 100,
-          "interval": "1d",
+          "interval": "12h",
           "intervals": [
             "auto",
             "1s",
@@ -571,7 +616,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=main_elements&facet.limit=10",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=main_elements&facet.limit=10",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "field": "main_elements",
@@ -593,7 +638,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=medical_conditions&facet.limit=10",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=0&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&facet=true&facet.field=medical_conditions&facet.limit=10",
             "custom": "&fq=credibility_label:(\"not credible\" OR \"mostly not credible\")"
           },
           "field": "medical_conditions",
@@ -615,7 +660,7 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&wt=json&rows=0&facet=true&facet.pivot=credibility_label,organizations&facet.limit=5&facet.pivot.mincount=0",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&rows=0&facet=true&facet.pivot=credibility_label,organizations&facet.limit=5&facet.pivot.mincount=0",
             "custom": ""
           },
           "size": 0,
@@ -639,22 +684,22 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label,medical_conditions&f.credibility_label.facet.limit=4&f.medical_conditions.facet.limit=20&rows=0",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&facet=true&facet.pivot=credibility_label,medical_conditions&f.credibility_label.facet.limit=4&f.medical_conditions.facet.limit=20&rows=0",
             "custom": ""
           },
           "facet_limit": "4,20",
-          "node_size_weight": 1,
+          "node_size_weight": 0.1,
           "link_width_weight": 1,
           "link_strength_weight": 0,
           "link_distance_weight": 0,
-          "strength": -100,
-          "colors": "#1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf",
+          "strength": -200,
+          "colors": "#693C5E, #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22",
           "mute_category_1": false,
           "mute_category_2": true,
           "spheres": true,
           "spyable": true,
           "show_queries": true,
-          "title": "People by doc credibility",
+          "title": "Medical Conditions by doc credibility",
           "facet_pivot_strings": [
             "credibility_label",
             "medical_conditions"
@@ -680,8 +725,8 @@
             "ids": [
               0
             ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]&wt=json&rows=50",
-            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-180DAY%20TO%20NOW%2B1DAY]",
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]&wt=json&rows=50",
+            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&fq=publishedDate:[NOW-90DAY%20TO%20NOW%2B1DAY]",
             "custom": "&hl=false&fq=credibility_label:*"
           },
           "size": 10,

--- a/src/app/panels/table/module.html
+++ b/src/app/panels/table/module.html
@@ -92,13 +92,13 @@
                 <a class="link" ng-class="{'strong':event.kibana.view == 'raw'}" ng-click="event.kibana.view = 'raw'">Raw</a>
                 <i class="link pull-right icon-chevron-up" ng-click="toggle_details(event)"></i>
               </span>
-              <table class='table table-bordered table-condensed' ng-switch-when="table">
+              <table class='table table-fixed table-bordered table-condensed' ng-switch-when="table">
                 <thead>
-                  <th>Field</th>
+                  <th class='narrowCol'>Field</th>
                   <!-- Disable action since it's not useful for most field types/values
                   <th>Action</th>
                   -->
-                  <th>Value</th>
+                  <th class='wideCol'>Value</th>
                 </thead>
                 <tr ng-repeat="(key,value) in event.kibana._source" ng-class-odd="'odd'">
                   <td>{{key}}</td>
@@ -110,7 +110,12 @@
                   </td>
                   -->
                   <!-- At some point we need to create a more efficient way of applying the filter pipeline -->
-                  <td style="white-space:pre-wrap" ng-bind-html-unsafe="value|noXml|urlLink|stringify"></td>
+                  <td ng-show="isMarkdownField(key)" ng-bind-html-unsafe="value
+                               | tableDisplayMarkdownField:key:panel.markdownFields
+                               "></td>
+                  <td ng-show="!isMarkdownField(key)"
+                      style="white-space:pre-wrap" ng-bind-html-unsafe="value
+                             |noXml|urlLink|stringify"></td>
                 </tr>
               </table>
               <pre style="white-space:pre-wrap"  ng-bind-html="without_kibana(event)|tableJson:2" ng-switch-when="json"></pre>

--- a/src/app/panels/table/module.js
+++ b/src/app/panels/table/module.js
@@ -23,10 +23,11 @@ define([
     'underscore',
     'kbn',
     'moment'
+    //'showdown'
     // 'text!./pagination.html',
     // 'text!partials/querySelect.html'
 ],
-function (angular, app, _, kbn, moment) {
+       function (angular, app, _, kbn, moment) {
     'use strict';
 
     var module = angular.module('kibana.panels.table', []);
@@ -92,6 +93,7 @@ function (angular, app, _, kbn, moment) {
             exportAll: true,
             displayLinkIcon: true,
             imageFields: [],      // fields to be displayed as <img>
+            markdownFields: ['credibility_explanation'],
             imgFieldWidth: 'auto', // width of <img> (if enabled)
             imgFieldHeight: '85px', // height of <img> (if enabled)
             show_queries: true,
@@ -261,6 +263,12 @@ function (angular, app, _, kbn, moment) {
             filterSrv.set({type: 'exists', field: field, mandate: mandate});
             dashboard.refresh();
         };
+
+        $scope.isMarkdownField = function (field) {
+            var result = (typeof field !== 'undefined' && $scope.panel.markdownFields.length > 0 && _.contains($scope.panel.markdownFields, field));
+            if (result) console.log('Field', field, 'is in markdownFields', $scope.panel.markdownFields);
+            return result;
+        }
 
         $scope.get_data = function (segment, query_id) {
             $scope.panel.error = false;
@@ -545,6 +553,21 @@ function (angular, app, _, kbn, moment) {
                 return '<img style="width:' + width + '; height:' + height + ';" src="' + data + '">';
             }
             return data;
+        };
+    });
+
+    // This filter will check the input field to see if it should be displayed as html from markdown
+    module.filter('tableDisplayMarkdownField', function () {
+        return function (text, field, markdownFields) {
+            
+            if (typeof field !== 'undefined' && markdownFields.length > 0 && _.contains(markdownFields, field)) {
+                var converter = new Showdown.converter();
+                var textConverted = text.replace(/&/g, '&amp;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/</g, '&lt;');
+                return converter.makeHtml(textConverted);
+            }
+            return text;
         };
     });
 });

--- a/src/css/bootstrap.ci.min.css
+++ b/src/css/bootstrap.ci.min.css
@@ -53,7 +53,7 @@ h2,h3{page-break-after:avoid}
 body{margin:0;font-family:"Open Sans",Helvetica,Arial,Lucida,sans-serif;font-size:14px;line-height:23.8px;color:#58334f;background-color:#6BBBAE
 }
 .row-fluid:after,.row-fluid:before,.row:after,.row:before{display:table;content:"";line-height:0}
-a{color:#693C5E;text-decoration:none}
+a{color:#0077b3;text-decoration:none}
 a:focus,a:hover{color:#59988e;text-decoration:underline}
 .img-rounded{-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}
 .img-polaroid{padding:4px;border:1px solid #ccc;border:1px solid rgba(0,0,0,.2);-webkit-box-shadow:0 1px 3px rgba(0,0,0,.1);-moz-box-shadow:0 1px 3px rgba(0,0,0,.1);box-shadow:0 1px 3px rgba(0,0,0,.1)}
@@ -310,6 +310,9 @@ table{max-width:100%;background-color:transparent;border-collapse:collapse;borde
 .table caption+thead tr:first-child td,.table caption+thead tr:first-child th,.table colgroup+thead tr:first-child td,.table colgroup+thead tr:first-child th,.table thead:first-child tr:first-child td,.table thead:first-child tr:first-child th{border-top:0}
 .table .table{background-color:#fff}
 .table-condensed td,.table-condensed th{padding:4px 5px}
+.table-fixed{table-layout: fixed}
+.table-fixed th.wideCol, .table-fixed td.wideCol {width: 80%}
+.table-fixed th.narrowCol, .table-fixed td.narrowCol {width: 15%}
 .table-bordered{border:1px solid #ddd;border-collapse:separate;border-left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}
 .table-bordered td,.table-bordered th{border-left:1px solid #ddd}
 .table-bordered caption+tbody tr:first-child td,.table-bordered caption+tbody tr:first-child th,.table-bordered caption+thead tr:first-child th,.table-bordered colgroup+tbody tr:first-child td,.table-bordered colgroup+tbody tr:first-child th,.table-bordered colgroup+thead tr:first-child th,.table-bordered tbody:first-child tr:first-child td,.table-bordered tbody:first-child tr:first-child th,.table-bordered thead:first-child tr:first-child th{border-top:0}


### PR DESCRIPTION
Table of document details now renders the credibility rating
explanation as markdown :)

Fixed name of Event row

Filter by published date now has more useful values by default

Added organizations and people to the facet filters component

Tweaked values in the force component as the bubbles were too big now
that we have around 30K rated documents

Added a counter for Rated Docs in the row of overviews and tweaked
labels