### PR TITLE
Custom doc+review components in table. Added Sidebar.

### DIFF
--- a/src/app/controllers/all.js
+++ b/src/app/controllers/all.js
@@ -1,5 +1,7 @@
 define([
   './dash',
   './dashLoader',
-  './row',
+    './row',
+    './sideColumn',
+    './ciDocument',
 ], function () {});

--- a/src/app/controllers/ciDocument.js
+++ b/src/app/controllers/ciDocument.js
@@ -1,0 +1,179 @@
+define([
+    'angular',
+    'app',
+    'underscore',
+    'moment'
+],
+function (angular, app, _, moment) {
+    'use strict';
+
+    var module = angular.module('kibana.controllers');
+
+    module.controller('CiDocumentCtrl', function ($scope, $rootScope, $timeout, ejsResource, sjsResource,
+                                                  dashboard,
+                                                  alertSrv, querySrv) {
+        var _d = {
+            title: "",
+            type: "Article"
+        };
+
+        $scope.init = function (ciDoc) {
+            $scope.querySrv = querySrv;
+            $scope.ciDoc = ciDoc;
+            console.log('Initialising ciDocumentCtr with ciDoc', ciDoc)
+            _.defaults($scope.ciDoc, _d)
+        };
+
+        $scope.isTweet = function() {
+            var result = $scope.ciDoc.url.startsWith('https://twitter.com/');
+            // console.log('Determining if doc is tweeet', result);
+            return result;
+        }
+        
+        $scope.isArticle = function() {
+            return !$scope.isTweet();
+        }
+
+        $scope.pubDate = function() {
+            var date = $scope.ciDoc.publishedDate;
+            return moment.utc(date).format('LT') + ' - ' + moment.utc(date).format('ll');
+        }
+
+        $scope.credReviewDate = function() {
+            var date = $scope.ciDoc.credibility_score_date;
+            return moment.utc(date).format('LT') + ' - ' + moment.utc(date).format('ll');
+        }
+
+        $scope.credLabelDescription = function() {
+            let label = $scope.ciDoc.credibility_label;
+            let label2Desc = {
+                credible: "Reviewed document is most likely to be accurate, according to strong signals we found",
+                "mostly credible": "Reviewed document is likely to be accurate, but may contain some minor inaccuracies, according to the (strong) signals we found",
+                "credibility uncertain": "Reviewed document probably mixes some accurate and inaccurate (or not verifiable) claims",
+                "mostly not credible": "Reviewed document is likely to be inaccurate, by may contain some accurate statements, according to the signals we found",
+                "not credible": "Reviewed document is likely to be inaccurate, according to strong signals we found",
+                "not verifiable": "Reviewed document does not contain verifiable claims (i.e. only opinions or speculation) or we could not find sufficient signals supporting/refuting the claims.",
+                "not verfiable": "Reviewed document does not contain verifiable claims (i.e. only opinions or speculation) or we could not find sufficient signals supporting/refuting the claims."
+            }
+            return label2Desc[label] || "";
+        }
+ 
+        $scope.viewableContent = function() {
+            if (($scope.ciDoc.content == null) || ($scope.ciDoc.content.length == 0)) {
+                return "<p>No textual content</p>";
+            }
+            return $scope.ciDoc.content.split("\n").map(p => "<p>"+p+"</p>").join();
+        }
+        $scope.reviewConfidence = function() {
+            return ($scope.ciDoc.credibility_confidence || 0.0).toFixed(2);
+        }
+        
+        $scope.explanation = function() {
+            function findNextDelimiterIndex(text, from) {
+                // console.debug("Finding next code delimiter in text", text.length,
+                //               "from", from, text.substring(from, from+10) + "...");
+                
+                var begin = text.indexOf("`", from);
+                var t = text.indexOf("```", from);
+                if (begin >= 0 && begin != t) {
+                    // console.debug("Found next delimiter at", begin,
+                    //               "..." + text.substring(Math.max(0, begin-5), begin + 10))
+                    return begin;
+                } else if (begin < 0) {
+                    return begin;
+                } else {
+                    return findNextDelimiterIndex(text, t+3);
+                }
+            }
+            function findMDCodeSpans(text, from) {
+                if (from > text.length) return [];
+                var result = [];
+                var begin = findNextDelimiterIndex(text, from);
+                if (begin >= 0) {
+                    // console.debug("Found start of code span at ", begin);
+                    var end = findNextDelimiterIndex(text, begin+1);
+                    if (end >= 0) {
+                        // console.debug("Found MD code span", begin, end, text.substring(begin, end));
+                        result.push([begin, end]);
+                        result.concat(findMDCodeSpans(text, end+1));
+                        return result;
+                    } else {
+                        // console.debug("Found unfinished span from", begin);
+                        return result;
+                    }
+                } else {
+                    // console.debug("text has no more code segments after", from);
+                    return result;
+                }
+            }
+            
+            function findMultilineCode(text, spans) {
+                return spans.filter(s => {
+                    let begin = s[0];
+                    let end = s[1];
+                    return text.substring(begin, end).indexOf("\n") >= 0;
+                });
+            }
+            
+            function fixMultilineCode(text) {
+                var spans = findMDCodeSpans(text, 0);
+                var mlSpans = findMultilineCode(text, spans);
+                console.debug("Found markdown code spans", mlSpans);
+                if (mlSpans.length == 0) {
+                    return text;
+                }
+                let startText = text.substring(0, mlSpans[0][0]);
+                let endText = text.substring(mlSpans[mlSpans.length-1][1]);
+                let fixed = mlSpans.reduce(
+                    (fixedText, currSpan) => {
+                        let span = text.substring(currSpan[0], currSpan[1]);
+                        let fixedSpan = span.replace(/\n/g, " ");
+                        // console.debug("Fixed span", currSpan, "\n\t", span, "\ninto:\n\t", fixedSpan);
+                        return fixedText + fixedSpan;
+                    },
+                    startText); //initial value
+                return fixed + endText;
+            }
+            
+            var converter = new Showdown.converter();
+            let text = fixMultilineCode($scope.ciDoc.credibility_explanation);
+            
+            var textConverted = text.replace(/&/g, '&amp;')
+                .replace(/>/g, '&gt;')
+                .replace(/</g, '&lt;');
+            return converter.makeHtml(textConverted);
+        }
+
+        module.filter('ciDocMarkdown', function() {
+            
+            return function(text) {
+                text = fixMultilineCode(text);
+                var converter = new Showdown.converter();
+                var textConverted = text.replace(/&/g, '&amp;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/</g, '&lt;');
+                return converter.makeHtml(textConverted);
+            }
+        })
+
+        $scope.rateReviewAsAccurate = function() {
+            alertSrv.set('Not implemented yet', 'This feature is not implemented yet', 'error');
+        }
+
+        $scope.rateReviewAsInaccurate = function() {
+            alertSrv.set('Not implemented yet', 'This feature is not implemented yet', 'error');
+        }
+
+        $scope.reviewIsAccurateStat = function() {
+            // TODO: add field to DB and return as part of doc when requested
+            return dashboard.numberWithCommas(0);
+        }
+
+        $scope.reviewIsInaccurateStat = function() {
+            // TODO: add field to DB and return as part of doc when requested
+            return dashboard.numberWithCommas(0);
+        }
+        
+        //$scope.init(null);
+    });
+});

--- a/src/app/controllers/sideColumn.js
+++ b/src/app/controllers/sideColumn.js
@@ -1,0 +1,77 @@
+// similar to the RowCtrl, except for panels that appear in the side panel
+// typically, this container will consists of the main filters
+define([
+    'angular',
+    'app',
+    'underscore'
+],
+function (angular, app, _) {
+    'use strict';
+
+    var module = angular.module('kibana.controllers');
+
+    module.controller('SideColumnCtrl', function ($scope, $rootScope, $timeout, dashboard, ejsResource, sjsResource, querySrv) {
+        var _d = {
+            title: "Column",
+            width: "250px",
+            collapse: false,
+            collapsable: true,
+            editable: true,
+            panels: []
+        };
+
+
+        $scope.init = function () {
+            _.defaults((dashboard.current.sideColumn || {}), _d);
+            $scope.querySrv = querySrv;
+            $scope.reset_panel();
+        };
+
+        $scope.toggle_column = function (col) {
+            if (!col.collapsable) {
+                return;
+            }
+            col.collapse = col.collapse ? false : true;
+            if (!col.collapse) {
+                $timeout(function () {
+                    $scope.$broadcast('render');
+                });
+            }
+        };
+
+        $scope.colSpan = function (col) {
+            var panels = _.filter(col.panels, function (p) {
+                return $scope.isPanel(p);
+            });
+            return _.reduce(_.pluck(panels, 'span'), function (p, v) {
+                return p + v;
+            }, 0);
+        };
+
+        // This can be overridden by individual panels
+        $scope.close_edit = function () {
+            $scope.$broadcast('render');
+        };
+
+        $scope.add_panel = function (col, panel) {
+            $scope.col.panels.push(panel);
+        };
+
+        $scope.reset_panel = function (type) {
+            /*
+            var
+                defaultSpan = 4,
+                _as = 12 - $scope.colSpan($scope.col);
+
+            $scope.panel = {
+                error: false,
+                span: _as < defaultSpan && _as > 0 ? _as : defaultSpan,
+                editable: true,
+                type: type
+            };
+            */
+        };
+
+        $scope.init();
+    });
+});

--- a/src/app/dashboards/dev-fakeNewsNet.json
+++ b/src/app/dashboards/dev-fakeNewsNet.json
@@ -1,50 +1,84 @@
 ﻿{
-  "title": "on Politifact FakeNewsNet v20200615",
+  "title": "on PolitiFact FakeNewsNet",
+  "version": "v20200615",
   "services": {
     "query": {
       "idQueue": [
+        0,
         1,
         2,
         3,
         4
       ],
       "list": {
-        "0": {
-          "query": "-credibility_label:\"not verifiable\"",
-          "alias": "",
-          "color": "#7EB26D",
-          "id": 0,
-          "pin": false,
-          "type": "lucene"
-        }
       },
       "ids": [
-        0
       ]
     },
     "filter": {
       "idQueue": [
         0,
+        1,  
         2,
         3,
         4,
         5
       ],
       "list": {
-        "1": {
-          "type": "terms",
-          "field": "credibility_label",
-          "mandate": "must",
-          "value": "not%20credible",
-          "active": false,
-          "alias": "",
-          "id": 1
-        }
       },
       "ids": [
-        1
       ]
     }
+  },
+  "sideColumn"  : {
+      "title": "Filters",
+      "width": "50px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 5,
+          "editable": true,
+          "type": "facet",
+          "loadingEditor": false,
+          "status": "Stable",
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ],
+            "query": "q=-credibility_label%3A%22not%20verifiable%22&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people&wt=json",
+            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people",
+            "custom": ""
+          },
+          "group": "default",
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "categories",
+            "credibility_label",
+            "source_id",
+            "organizations",
+            "people"
+          ],
+          "spyable": true,
+          "facet_limit": 10,
+          "maxnum_facets": 6,
+          "foundResults": true,
+          "header_title": "",
+          "toggle_element": null,
+          "show_queries": false,
+          "title": "Filters",
+          "exportSize": null,
+          "offset": 0,
+          "show_help_message": true,
+          "info_mode": "markdown",
+          "help_message": "Use this component to see (and define filters for) the main;\n\n* `categories` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility label`s: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents.\n* `organizations`: which have been identified as being mentioned in the text\n* `people`: who have been mentioned in the text"
+        }
+      ]
   },
   "rows": [
     {
@@ -80,68 +114,6 @@
           "content": "## Changelog\n\n#### v20200615\n* First version",
           "style": {},
           "title": "Development Notes"
-        }
-      ]
-    },
-    {
-      "title": "Filters",
-      "height": "50px",
-      "editable": true,
-      "collapse": true,
-      "collapsable": true,
-      "panels": [
-        {
-          "error": false,
-          "span": 2,
-          "editable": true,
-          "type": "text",
-          "loadingEditor": false,
-          "status": "Stable",
-          "mode": "markdown",
-          "content": "Use the *timepicker* and/or *filter*s to the right to filter by time, topic, language, etc.",
-          "style": {},
-          "title": "Filter results"
-        },
-        {
-          "span": 5,
-          "editable": true,
-          "type": "facet",
-          "loadingEditor": false,
-          "status": "Stable",
-          "queries": {
-            "mode": "all",
-            "ids": [
-              0
-            ],
-            "query": "q=-credibility_label%3A%22not%20verifiable%22&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people&wt=json",
-            "basic_query": "q=-credibility_label%3A%22not%20verifiable%22&facet=true&facet.field=categories&facet.field=credibility_label&facet.field=source_id&facet.field=organizations&facet.field=people",
-            "custom": ""
-          },
-          "group": "default",
-          "style": {
-            "font-size": "9pt"
-          },
-          "overflow": "min-height",
-          "fields": [
-            "categories",
-            "credibility_label",
-            "source_id",
-            "organizations",
-            "people"
-          ],
-          "spyable": true,
-          "facet_limit": 10,
-          "maxnum_facets": 6,
-          "foundResults": true,
-          "header_title": "Filters",
-          "toggle_element": null,
-          "show_queries": false,
-          "title": "Filters",
-          "exportSize": null,
-          "offset": 0,
-          "show_help_message": true,
-          "info_mode": "markdown",
-          "help_message": "Use this component to see (and define filters for) the main;\n\n* `categories` these are topics identified automatically using [Expert System](http://expertsystem.com)'s [Cogito](https://expertsystem.com/products/cogito-intelligence-platform/) natural language processing. \n* `credibility label`s: these are automatically assigned to documents based on a state-of-the-art misinformation detection algorithm that tries to link sentences in documents to previously fact-checked claims.  \n* `source_id`: name of the source of documents, this is typically the website or twitter hashtag used to collect documents.\n* `organizations`: which have been identified as being mentioned in the text\n* `people`: who have been mentioned in the text"
         }
       ]
     },
@@ -720,7 +692,7 @@
             ],
             "query": "q=-credibility_label%3A%22not%20verifiable%22&wt=json&rows=50",
             "basic_query": "q=-credibility_label%3A%22not%20verifiable%22",
-            "custom": "&hl=false&fq=credibility_label:*&fl=content,contentLength,content_language,credibility_assessor,credibility_confidence,credibility_explanation,credibility_label,credibility_score,credibility_score_date,domain_credibility_confidence,domain_credibility_explanation,domain_credibility_label,domain_credibility_score,domain_credibility_score_date,lang,lang_orig,lastModified,last_update,publishedDate,retrieved_on,size,source,source_id,title,url"
+            "custom": "&hl=false&fq=credibility_label:*&fl=id,content,contentLength,content_language,credibility_assessor,credibility_confidence,credibility_explanation,credibility_label,credibility_score,credibility_score_date,domain_credibility_confidence,domain_credibility_explanation,domain_credibility_label,domain_credibility_score,domain_credibility_score_date,lang,lang_orig,lastModified,last_update,publishedDate,retrieved_on,size,source,source_id,title,url"
           },
           "size": 10,
           "pages": 5,
@@ -798,7 +770,8 @@
           "hyperlinkColumnForURI": "url",
           "markdownFields": [
             "credibility_explanation"
-          ]
+          ],
+            "withReviewGraph": true
         }
       ]
     }

--- a/src/app/panels/heatmap/module.js
+++ b/src/app/panels/heatmap/module.js
@@ -251,8 +251,14 @@ define([
 
             $scope.build_search = function(x, y) {
                 if (x && y) {
-                  filterSrv.set({type: 'terms', field: $scope.panel.row_field, value: x, mandate: 'must'});
-                  filterSrv.set({type: 'terms', field: $scope.panel.col_field, value: y, mandate: 'must'});
+                    var rowVal = x;
+                    var colVal = y;
+                    if ($scope.panel.transposed) {
+                        rowVal = y;
+                        colVal = x;
+                    };
+                  filterSrv.set({type: 'terms', field: $scope.panel.row_field, value: rowVal, mandate: 'must'});
+                  filterSrv.set({type: 'terms', field: $scope.panel.col_field, value: colVal, mandate: 'must'});
                 } else {
                   return;
                 }

--- a/src/app/panels/table/module.html
+++ b/src/app/panels/table/module.html
@@ -56,9 +56,9 @@
         </thead>
 
         <!-- Table Content -->
-        <tbody ng-repeat="event in data | slice:panel.offset:panel.offset+panel.size" ng-class-odd="'odd'">
+        <tbody  ng-repeat="event in data | slice:panel.offset:panel.offset+panel.size" ng-class-odd="'odd'">
           <!-- Main Row -->
-          <tr ng-click="toggle_details(event)" class="pointer">
+          <tr ng-click="toggle_details(event)" class="pointer table-row">
             <td ng-show="panel.fields.length<1">{{event.kibana._source|stringify|tableTruncate:panel.trimFactor:1}}</td>
 
             <!-- Column Values -->
@@ -83,15 +83,24 @@
           </tr>
 
           <!-- Show full details of the row when clicked -->
-          <tr ng-show="event.kibana.details">
+          <tr class="tr-details" ng-show="event.kibana.details">
             <td colspan={{panel.fields.length}} ng-switch="event.kibana.view">
               <span>
                 View:
+                <a class="link" ng-class="{'strong':event.kibana.view == 'custom'}" ng-click="event.kibana.view = 'custom'">Doc+Review</a> /
                 <a class="link" ng-class="{'strong':event.kibana.view == 'table'}" ng-click="event.kibana.view = 'table'">Table</a> /
+                <!--
                 <a class="link" ng-class="{'strong':event.kibana.view == 'json'}" ng-click="event.kibana.view = 'json'">JSON</a> /
                 <a class="link" ng-class="{'strong':event.kibana.view == 'raw'}" ng-click="event.kibana.view = 'raw'">Raw</a>
+                -->
+                <button type="button" class="btn btn-primary"
+                        ng-show="panel.withReviewGraph"
+                        ng-click="displayReviewGraph(event)">Display Review Graph</button>
                 <i class="link pull-right icon-chevron-up" ng-click="toggle_details(event)"></i>
               </span>
+              <div class='' ng-switch-when="custom">
+                <div ng-controller='CiDocumentCtrl' ng-init="init(event.kibana._source)" ng-include="'app/partials/ciDocument.html'"></div>
+              </div>
               <table class='table table-fixed table-bordered table-condensed' ng-switch-when="table">
                 <thead>
                   <th class='narrowCol'>Field</th>
@@ -118,9 +127,12 @@
                              |noXml|urlLink|stringify"></td>
                 </tr>
               </table>
+              
               <pre style="white-space:pre-wrap"  ng-bind-html="without_kibana(event)|tableJson:2" ng-switch-when="json"></pre>
               <pre ng-bind-html="without_kibana(event)|tableJson:1" ng-switch-when="raw"></pre>
             </td>
+            <td>
+              </td>
           </tr>
         </tbody>
       </table>

--- a/src/app/panels/table/module.js
+++ b/src/app/panels/table/module.js
@@ -228,9 +228,14 @@ define([
 
         $scope.toggle_details = function (row) {
             row.kibana.details = row.kibana.details ? false : true;
-            row.kibana.view = row.kibana.view || 'table';
+            row.kibana.view = row.kibana.view || 'custom';
             //row.kibana.details = !row.kibana.details ? $scope.without_kibana(row) : false;
         };
+
+        $scope.displayReviewGraph = function(row) {
+            console.log('TODO: displayReviewGraph for', row.kibana._source);
+            solrSrv.fetchReviewGraph(row.kibana._source)
+        }
 
         $scope.page = function (page) {
             $scope.panel.offset = page * $scope.panel.size;

--- a/src/app/partials/ciDocument.html
+++ b/src/app/partials/ciDocument.html
@@ -1,0 +1,115 @@
+<!-- This file is responsible for displaying a Co-inform Document -->
+<div class="ciDocument">
+  <div class="ciTweet" ng-show="isTweet()">
+    <blockquote class="twitter-tweet" data-dnt="true">
+      <div class="pseudoEmbedded-tweet">
+        <div class="pseudoTweet-header">
+          <p><img class="Avatar" src="img/user-icon.svg"></img></p>
+          <div class="pseudoTweetAuthor">
+            <a class="pseudoTweetAuthor-link" href="https://twitter.com/{{ciDoc.author.substr(1)}}"'>
+              <div class="pseudoTweetAuthor-nameScreenNameContainer">
+                <span class="pseudoTweetAuthor-decoratedName">
+                  <span class="pseudoTweetAuthor-name">{{ciDoc.title}}</span>
+                </span>
+                <span class="pseudoTweetAuthor-screenName">{{ciDoc.author}}</span>
+              </div>
+            </a>
+          </div>
+          <div class="pseudoTweet-brand">
+            <a href="{{ciDoc.url}}">
+              <span class="FollowButton-bird">
+                <div class="icon-twitter" title="View on Twitter"></div>
+              </span>
+            </a>
+          </div>
+        </div>
+        <div class="pseudoTweet-body">
+          
+          <p class="pseudoTweet-text" lang="{{ciDoc.lang_orig}}" dir="ltr">{{ciDoc.content}}</p>
+          <div class="pseudoTweetInfo">
+            <div class="pseudoTweetInfo-timeGeo">
+              <a href="{{ciDoc.url}}">{{pubDate()}}</a>
+            </div>
+            <!--
+                 <a href="{{ciDoc.url}}?ref_src=twsrc%5Etfw">{{pubDate()}}</a>
+            -->
+          </div>
+        </div>
+      </div>
+    </blockquote>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    
+  </div>
+  <div class="ciGenericDoc" ng-show="isArticle()">
+    <blockquote class="ciArticle">
+      <div class="article-header">
+        <p><img class="Avatar-square" src="img/article_symbol.svg"></img></p>
+        <div class="articlePublisher">
+          <a class="articlePublisher-link" href="{{ciDoc.url}}">
+            <div class="article-decoratedNameContainer">
+              <span class="article-title">
+                <span class="articleTitle">{{ciDoc.title}}</span>
+              </span>
+            </div>
+          </a>
+        </div>
+        <div class="article-brand">
+          <a href="{{ciDoc.domain}}">
+            <span class="">
+              <a class="icon-news" title="Visit Publisher"></a>
+            </span>
+          </a>
+      </div>
+    </div>
+    <div class="article-body">
+      <div ng-bind-html="viewableContent()"></div>
+      <div class="articleInfo">
+        <div class="articleInfo-timeGeo">
+          <a title="Date published (if unknown: date retrieved)" href="{{ciDoc.url}}">{{pubDate()}}</a>
+        </div>
+      </div>
+    </div>
+  </blockquote>
+ </div>
+ <div class="CredibilityReview">
+   <div class="credReview-header">
+     <p><img class="Avatar-square" title="{{ciDoc.credibility_assessor}}" src="img/bot_symbol.svg"></img></p>
+     <div class="RatingRater">
+       <div class="reviewLabelContainer">
+         <span class="reviewLabel">
+           <span class="reviewLabel" title="{{credLabelDescription()}}">{{ciDoc.credibility_label}}</span>
+           <span class="reviewConfidence" title="Credibility signal strength | 0.0 means weak, 1.0 means strong">{{reviewConfidence()}}</span>
+         </span>
+         <span class="reviewer">{{ciDoc.credibility_assessor}}</span>
+       </div>
+     </div>
+     <div class="review-brand">
+       <a class="icon-info" title="This review was generated automatically by an AI system. It compared the sentences in the document with 45,000 claims reviewed by fact-checkers and 40,000 sentences extracted from news sites."></a>
+     </div>
+   </div>
+   <div class="review-body">
+     <div class="CredibilityReview-Explanation"
+               ng-bind-html="explanation()">
+     </div>
+     <div class="reviewInfo">
+       <div class="reviewInfo-actions">
+         <span class="rate" title="This review is accurate (help us improve our AI)"
+               ng-click="rateReviewAsAccurate()">
+           <a class="icon-ok"></a>
+           <span class="accurate-stat" title="Number of Co-inform users who have rate this review as accurate">{{reviewIsAccurateStat()}}</span>
+         </span>
+         &nbsp;|&nbsp;
+         <span title="This review is inaccurate (help us improve our AI)"
+               ng-click="rateReviewAsInaccurate()">
+           <a class="icon-remove"></a>
+           <span class="accurate-stat" title="Number of Co-inform users who have rate this review as inaccurate">{{reviewIsInaccurateStat()}}</span>
+         </span>
+       </div>
+       <div class="reviewInfo-timeGeo">
+         <span title="Reviewed On">{{credReviewDate()}}</span>
+       </div>
+     </div>
+   </div>
+ </div>
+  
+</div>

--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -22,12 +22,19 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
         // A hash of defaults to use when loading a dashboard
         var _dash = {
             title: "",
+            version: "",
             username: "guest", // default
-            style: "dark",
+            style: "ci",
             editable: true,
             home: true,
             failover: false,
             panel_hints: true,
+            sideColumn: {
+                title: "Filters",
+                width: "250px",
+                editable: true,
+                panels: [],
+            },
             rows: [],
             services: {},
             loader: {
@@ -117,7 +124,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
                         self.script_load(_id);
                         break;
                     default:
-                        self.file_load('default.json');
+                        self.file_load('coinform');
                 }
 
                 // No dashboard in the URL
@@ -130,7 +137,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
                     self.dash_load(dashboard);
                     // No? Ok, grab default.json, its all we have now
                 } else {
-                    self.file_load('coinform.json');
+                    self.file_load('coinform');
                 }
             }
         };
@@ -308,8 +315,9 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
         };
 
         this.file_load = function (file) {
+            let jFile = file.endsWith('.json') ? file : file+".json";
             return $http({
-                url: "app/dashboards/" + file + '?' + new Date().getTime(),
+                url: "app/dashboards/" + jFile + '?' + new Date().getTime(),
                 method: "GET",
                 transformResponse: function (response) {
                     return renderTemplate(response, $routeParams);
@@ -321,7 +329,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
                 self.dash_load(dash_defaults(result.data));
                 return true;
             }, function () {
-                alertSrv.set('Error', "Could not load <i>dashboards/" + file + "</i>. Please make sure it exists", 'error');
+                alertSrv.set('Error', "Could not load <i>dashboards/" + jFile + "</i>. Please make sure it exists", 'error');
                 return false;
             });
         };

--- a/src/app/services/solrSrv.js
+++ b/src/app/services/solrSrv.js
@@ -18,6 +18,51 @@ function (angular, _) {
       return self.topFieldValues[field];
     };
 
+    this.fetchReviewGraph = function(doc) {
+        let doc_id = doc['id'];
+        let baseUrl = dashboard.current.solr.server
+        let collection = dashboard.current.solr.core_name;
+        var request = $http({
+            method: 'GET',
+            url: baseUrl + "/reviewGraph/" + collection + "?id=" + doc_id
+        }).error(function(data, status) {
+            if(status === 0) {
+                alertSrv.set('Error', 'Could not retrieve Review Graph at '+baseUrl+
+                             '. Please ensure that the server is reachable from your system.' ,'error');
+            } else {
+                alertSrv.set('Error','Could not retrieve Review Graph data from server (Error status = '+status+')','error');
+            }     
+        }).success(function(data, status) {
+            var result = data['results'][0]
+            //console.log('Got response back from server for doc_id: ', result['doc_id'], result);
+            var graph = result['reviewGraph'];
+            if (graph == null) {
+                alertSrv.set('Warning', 'No review available for this document. Sorry.');
+            } else {
+                console.log('Retrieved review graph with', graph['nodes'].length, 'nodes and', graph['links'].length, 'links');
+                //TODO: trigger display of graph
+            }            
+        });
+
+        // request.then(function(response){
+        //     if (typeof response === 'undefined') {
+        //         alertSrv.set('Error', 'Could not retrieve Review Graph for unkown reasons')
+        //     } else if (response['status'] == 200){
+        //         var result = response['data']['results'][0]
+        //         console.log('Got response back from server for doc_id: ', result['doc_id'], result);
+        //         var graph = result['reviewGraph'];
+        //         if (graph == null) {
+        //             alertSrv.set('Warning', 'No review available for this document. Sorry.');
+        //         } else {
+        //             console.log('Retrieved review graph with', graph['nodes'].length, 'nodes and', graph['links'].length, 'links');
+        //         }
+        //     } else {
+        //         alertSrv.set('Error',
+        //                      'Could not retrieve Review Graph from server (Error status ='+response['status']+')')
+        //     }
+        // });
+    };
+      
     // Calculate each field top 10 values using facet query
     this.calcTopFieldValues = function(fields) {
       // Check if we are calculating too many fields and show warning

--- a/src/css/bootstrap.ci.min.css
+++ b/src/css/bootstrap.ci.min.css
@@ -43,7 +43,7 @@ a[href]:after{content:" (" attr(href) ")"}
 abbr[title]:after{content:" (" attr(title) ")"}
 .ir a:after,a[href^="#"]:after,a[href^="javascript:"]:after{content:""}
 blockquote,pre{border:1px solid #999}
-thead{display:table-header-group}
+thead{display:table-header-group;background-color:#58334f;color:white;}
 img{max-width:100%!important}
 @page{margin:.5cm}
 h2,h3,p{orphans:3;widows:3}
@@ -303,6 +303,7 @@ legend+.control-group{margin-top:20px;-webkit-margin-top-collapse:separate}
 .form-horizontal .form-actions{padding-left:180px}
 table{max-width:100%;background-color:transparent;border-collapse:collapse;border-spacing:0}
 .table{width:100%;margin-bottom:20px}
+.table thead{background-color:#58334f;color:white;}
 .table td,.table th{padding:8px;line-height:20px;text-align:left;vertical-align:top;border-top:1px solid #ddd}
 .btn,.pagination-centered{text-align:center}
 .table th{font-weight:700}
@@ -325,7 +326,7 @@ table{max-width:100%;background-color:transparent;border-collapse:collapse;borde
 .table-bordered caption+tbody tr:first-child td:first-child,.table-bordered caption+thead tr:first-child th:first-child,.table-bordered colgroup+tbody tr:first-child td:first-child,.table-bordered colgroup+thead tr:first-child th:first-child{-webkit-border-top-left-radius:4px;-moz-border-radius-topleft:4px;border-top-left-radius:4px}
 .table-bordered caption+tbody tr:first-child td:last-child,.table-bordered caption+thead tr:first-child th:last-child,.table-bordered colgroup+tbody tr:first-child td:last-child,.table-bordered colgroup+thead tr:first-child th:last-child{-webkit-border-top-right-radius:4px;-moz-border-radius-topright:4px;border-top-right-radius:4px}
 .table-striped tbody>tr:nth-child(odd)>td,.table-striped tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}
-.table-hover tbody tr:hover>td,.table-hover tbody tr:hover>th{background-color:#f5f5f5}
+.table-hover tbody tr.table-row:hover>td,.table-hover tbody tr.table-row:hover>th{background-color:#6bbbae;color:white;}
 .row-fluid table td[class*=span],.row-fluid table th[class*=span],table td[class*=span],table th[class*=span]{display:table-cell;float:none;margin-left:0}
 .table td.span1,.table th.span1{float:none;width:44px;margin-left:0}
 .table td.span2,.table th.span2{float:none;width:124px;margin-left:0}
@@ -929,6 +930,7 @@ to{background-position:0 0}
 .carousel-caption p{margin-bottom:0}
 .hero-unit{padding:60px;margin-bottom:30px;font-size:18px;font-weight:200;line-height:30px;color:inherit;background-color:#eee;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}
 .panelCont,.row-close{outline:#e6e6e6 solid 1px;background:#fbfbfb}
+.sidebar .panelCont,.row-close{outline:#e6e6e6 solid 1px;background:#693c5e;}
 .hero-unit h1{margin-bottom:0;font-size:60px;line-height:1;color:inherit;letter-spacing:-1px}
 .hero-unit li{line-height:30px}
 .pull-right{float:right}
@@ -939,6 +941,7 @@ to{background-position:0 0}
 .affix{position:fixed}
 .panel-error,.panel-loading,.row-open,.spy{position:absolute}
 .panelCont{border-top:1px solid #fff;padding:0 11px 11px;margin:0}
+.sidebar .panelCont{border-top:0px solid #fff; padding:0 11px 11px;margin:0}
 #events{font-size:12px}
 .version{font-size:85%}
 .legend{color:#000}
@@ -987,3 +990,548 @@ to{background-position:0 0}
 .faded{opacity:.2}
 div.flot-text{color:#333!important}
 .dashboard-notice{z-index:8000;margin-left:0;padding:3px 0 3px 20px;width:100%;color:#333}
+.sidebar {
+  height: 100%;
+  width: 0;
+  position: fixed;
+  z-index: 2;
+  top: 57px;
+  left: 0;
+  color: white;
+  background-color: #693c5e;
+  overflow-x: hidden;
+  transition: 0.5s;
+  padding-top: 10px;
+  border-top: solid;
+}
+.main{
+  transition: 0.5s;
+  margin-top: 15px;
+}
+.openbtn {
+  color: white;
+  background-color: #693c5e;
+  transition: 0.5s;
+  border: 0 0 0 0;
+  position:fixed;
+  z-index: 1;
+}
+
+.sidebar .closebtn {
+  position: absolute;
+  color: white;
+  dtop: 57px;
+  right: 15px;
+  top: 5px;
+  font-size: 22px;
+  margin-left: 50px;
+}
+
+.sidebar a {
+  color: white;
+}
+
+.sidebar .row-button {
+  border-bottom: 0px;
+  border-left: 0px;
+  border-right: 0px;
+}
+
+.sidebar .panel div.panel-extra .extra {
+  border-bottom: 0px;
+}
+
+@media screen and (max-height: 450px) {
+  .sidebar {padding-top: 15px;}
+  .sidebar a {font-size: 18px;}
+}
+.main-footer {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  background-color: #693c5e;
+  color: white;
+  position: relative;
+  height: 150px;
+  z-index:10;
+}
+.main-footer-inner {
+  padding-top: 30px;
+  padding-bottom: 30px;
+  margin-left: 50px;
+  margin-right: 50px;
+  font-size: x-large;
+  font-family: 'Capriola',sans-serif;
+  width: 60%;
+  float: left;
+}
+.social-media {
+  margin-right: 0px;
+  width: 15%;
+  position: relative;
+  float: right;
+  margin-right: 100px;
+  color: white;
+  padding-top: 30px;
+  padding-bottom: 30px;
+}
+.social-media-follow {
+  display: inline-block;
+  position: relative;
+  margin-bottom: 8px;
+}
+.social-media-follow a{
+  color: white;
+  box-sizing: content-box;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  display: block;
+  font-size: 16px;
+  line-height: 32px;
+}
+
+.main-footer-funding {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  margin-bottom: 0px;
+  background-color: white;
+  position: relative;
+  z-index:10;
+}
+.funding-divider {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDBweCIgdmlld0JveD0iMCAwIDEyODAgMTQwIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9IiM2OTNjNWUiPjxwYXRoIGQ9Ik0xMDkzLjQ4IDEzMS44NUwxNzMgOTRhNzYuODUgNzYuODUgMCAwIDEtMzYuNzktMTEuNDZMMCAwdjE0MGgxMjgwVjBsLTEzMS44MSAxMTEuNjhjLTE2LjQ3IDEzLjk2LTM1LjQ3IDIwLjk2LTU0LjcxIDIwLjE3eiIvPjwvZz48L3N2Zz4=);
+  background-size: 100% 100px;
+  top: 0;
+  height: 100px;
+  z-index: 1;
+  transform: rotateX(180deg);
+  width: 100%;
+  display: block;
+  position: absolute;
+}
+.funding-inner {
+  padding-top: 77px;
+  padding-bottom: 27px;
+  z-index: 5;
+  margin: auto;
+  position: relative;
+  width: 80%;
+  max-width: 1080px;
+}
+.funding-inner::after {
+  display: block;
+  visibility: hidden;
+  clear: both;
+  width:0;
+  height: 0;
+  line-height: 0;
+  content: ".";
+}
+.ec-logos {
+  width: 30%;
+  margin-right: 5.5%;
+  z-index: 9;
+  position: relative;
+  float: left;
+}
+.image_wrap {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+.funding-text {
+  margin-right: 0px;
+  width: 60%;
+  position: relative;
+  float: left;
+}
+.ciDocument {
+  display: flex;
+}
+.CredibilityReview {
+  padding: 20px 20px 11.6px 20px;
+  with: 50%;
+  overflow: hidden;
+  cursor: pointer;
+  background-color: #fff;
+  border: 1px solid #e1e8ed;
+  border-radius: 5px;
+  max-width: 550px;
+  margin-left: 15px;
+}
+.CredibilityReview p {
+  font-size: 17.5px;
+  font-weight: 300;
+  line-height: 1.25;
+}
+.CredibilityReview-Explanation code {
+  white-space: normal;
+}
+.twitter-tweet-error::before {
+  color: red;
+  content: "Failed to retrieve tweet, maybe it was removed. The original (possibly translated) text was:";
+}
+.twitter-tweet {
+  overflow: hidden;
+  cursor: pointer;
+  background-color: #fff;
+  border: 1px solid #e1e8ed;
+  border-radius: 5px;
+  max-width: 550px;  
+}
+.twitter-tweet-error {
+
+}
+.twitter-tweet-error:hover {
+  border-color: #ccd6dd;
+}
+.pseudoEmbedded-tweet {
+  padding: 20px 20px 11.6px 20px;
+}
+.ciArticle {
+  padding: 20px 20px 11.6px 20px;
+  overflow: hidden;
+  cursor: pointer;
+  background-color: #fff;
+  border: 1px solid #e1e8ed;
+  border-radius: 5px;
+  max-width: 550px;
+}
+.article-header {
+  display: flex;
+}
+.pseudoTweet-header {
+  display: flex;
+}
+.credReview-header {
+  display: flex;
+}
+.pseudoTweet-avatar {
+  -webkit-flex-basis: 36px;
+  -ms-flex-preferred-size: 36px;
+  flex-basis: 36px;
+  -webkit-box-flex: 0;
+  -webkit-flex: none;
+  -moz-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  height: 36px;
+  background-color: transparent;
+  margin-right: 9px;
+}
+.pseudoTweet-body {
+  margin-top: 13px;
+}
+.article-body {
+  margin-top: 13px;
+}
+.review-body {
+  margin-top: 13px;
+}
+.pseudoTweet-text {
+  white-space: pre-wrap;
+  cursor: text;
+  color:rgb(28, 32, 34);
+  font-family:Helvetica, Roboto, "Segoe UI", Calibri, sans-serif;
+  font-size:16px;
+  font-stretch:100%;
+}
+.Avatar {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 50%;
+  flex-basis: 36px;
+  width: 36px;
+  margin-right: 9px;
+  color: #1da1f2;
+}
+.Avatar-square {
+  max-width: 100%;
+  max-height: 100%;
+  flex-basis: 36px;
+  width: 36px;
+  margin-right: 9px;
+  color: #1da1f2;  
+}
+
+.articlePublisher {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+}
+.RatingRater {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+}
+.pseudoTweetAuthor {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+}
+.reviewLabelContainer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  line-height: 1.2;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -moz-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  min-width: 0;
+}
+.pseudoTweetAuthor-link {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -moz-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+.article-decoratedNameContainer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  line-height: 1.2;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -moz-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  min-width: 0;
+}
+.pseudoTweetAuthor-nameScreenNameContainer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -moz-box-orient: vertical;
+  -moz-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  line-height: 1.2;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -moz-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  min-width: 0;
+}
+.reviewLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 4px;
+  color: rgb(28, 32, 34);
+  font-weight: 700;
+  font-size: 16px;
+}
+.reviewConfidence {
+  color: #697882;
+  font-size: 10px
+}
+.article-title {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -moz-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+}
+.pseudoTweetAuthor-decoratedName {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -moz-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+}
+.articleTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 4px;
+  color: rgb(28, 32, 34);
+  font-weight: 700;
+  font-size: 16px;
+}
+.pseudoTweetAuthor-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 4px;
+  color: rgb(28, 32, 34);
+  font-weight: 700;
+  font-size: 16px;
+}
+.reviewer {
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  color: #697882;  
+}
+.pseudoTweetAuthor-screenName {
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  color: #697882;
+}
+.pseudoTweet-brand {
+  margin-left: auto;
+}
+.review-brand {
+  margin-left: auto;
+}
+.article-brand {
+  marging-left: auto;
+}
+.FollowButton-bird {
+  width: 1.25em;
+  font-size: 20px;
+  color: #1da1f2;
+}
+.reviewInfo {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 10.4px;
+  font-size: 14px;  
+}
+.articleInfo {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 10.4px;
+  font-size: 14px;
+}
+.pseudoTweetInfo {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 10.4px;
+  font-size: 14px;
+}
+.reviewInfo-timeGeo {
+  margin-left: 12px;
+  color: #697882;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -moz-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;    
+}
+.articleInfo-timeGeo {
+  margin-left: 12px;
+  color: #697882;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -moz-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;  
+}
+.pseudoTweetInfo-timeGeo{
+  margin-left: 12px;
+  color: #697882;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -moz-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+.pseudoTweetInfo-timeGeo a{
+  color: #697882;
+}
+
+

--- a/src/img/article_symbol.svg
+++ b/src/img/article_symbol.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg2098"
+   version="1.1"
+   viewBox="0 0 15.544351 15.544139"
+   height="15.544139mm"
+   width="15.544351mm">
+  <title
+     id="title2134">article</title>
+  <defs
+     id="defs2092" />
+  <metadata
+     id="metadata2095">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>article</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 1.6361987,1.1082787 c -0.29247,0 -0.52792,0.23712 -0.52792,0.53168 V 13.971129 c 0,0.29448 0.23545,0.53155 0.52792,0.53155 H 13.974779 c 0.29263,0 0.52811,-0.23707 0.52811,-0.53155 V 1.6399587 c 0,-0.29445 -0.23548,-0.53157 -0.52811,-0.53157 H 1.6361987 Z"
+     style="fill:none;stroke:#ffffff;stroke-width:2.1497395;stroke-linecap:round;stroke-linejoin:round"
+     id="path1097" />
+  <path
+     d="m 1.6361987,1.1082787 c -0.29247,0 -0.52792,0.23712 -0.52792,0.53168 V 13.971129 c 0,0.29448 0.23545,0.53155 0.52792,0.53155 H 13.974779 c 0.29263,0 0.52811,-0.23707 0.52811,-0.53155 V 1.6399587 c 0,-0.29445 -0.23548,-0.53157 -0.52811,-0.53157 H 1.6361987 Z"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.82682288;stroke-linecap:round;stroke-linejoin:round"
+     id="rect812" />
+  <path
+     id="rect912"
+     style="fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:1.32293558;stroke-linecap:round;stroke-linejoin:round"
+     d="m 9.4894087,6.1327987 c -0.31212,0 -0.56339,0.25127 -0.56339,0.56339 v 2.21856 c 0,0.31212 0.25127,0.56339 0.56339,0.56339 h 2.2185603 c 0.31212,0 0.56339,-0.25127 0.56339,-0.56339 v -2.21856 c 0,-0.31212 -0.25127,-0.56339 -0.56339,-0.56339 z" />
+  <path
+     id="path842"
+     style="fill:none;stroke:#000000;stroke-width:1.32291102;stroke-linecap:round;stroke-linejoin:round"
+     d="M 3.3399487,3.3407487 H 12.271359" />
+  <path
+     id="path844"
+     style="fill:none;stroke:#000000;stroke-width:1.32293558;stroke-linecap:round;stroke-linejoin:round"
+     d="m 3.3399487,6.3473587 2.86792,-0.0453" />
+  <path
+     id="path845"
+     style="fill:none;stroke:#000000;stroke-width:1.32293558;stroke-linecap:round;stroke-linejoin:round"
+     d="m 3.3399487,9.3088987 h 2.84082" />
+  <path
+     id="path914"
+     style="fill:none;stroke:#000000;stroke-width:1.3229146;stroke-linecap:round;stroke-linejoin:round"
+     d="M 3.3401387,12.270339 H 12.271259" />
+</svg>

--- a/src/img/bot_symbol.svg
+++ b/src/img/bot_symbol.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="19.002228mm"
+   height="15.059771mm"
+   viewBox="0 0 19.002228 15.059771"
+   version="1.1"
+   id="svg1962">
+  <title
+     id="title1988">bot</title>
+  <defs
+     id="defs1956" />
+  <metadata
+     id="metadata1959">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>bot</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path16394"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:1.28339362;stroke-linecap:round;stroke-linejoin:round"
+     d="m 3.5992751,2.4202048 c -0.281102,0 -0.507402,0.2128 -0.507402,0.47716 V 13.964185 c 0,0.26429 0.2263,0.47705 0.507402,0.47705 H 15.458238 c 0.281255,0 0.50758,-0.21275 0.50758,-0.47705 V 2.8973648 c 0,-0.26426 -0.226325,-0.47707 -0.50758,-0.47707 H 3.5992751 Z" />
+  <circle
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path16402"
+     cx="6.9878783"
+     cy="6.3425813"
+     r="1.6063988" />
+  <circle
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="circle16406"
+     cx="12.06861"
+     cy="6.4036775"
+     r="1.6063988" />
+  <rect
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.09470218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect16408"
+     width="2.477541"
+     height="1.4084628"
+     x="4.909986"
+     y="10.229605" />
+  <rect
+     y="10.196196"
+     x="8.3176699"
+     height="1.4084628"
+     width="2.477541"
+     id="rect16410"
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.09470218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.09470218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect16412"
+     width="2.477541"
+     height="1.4084628"
+     x="11.725356"
+     y="10.196196" />
+  <path
+     d="m 15.952179,5.0299448 c -0.05976,0 -0.107877,0.11 -0.107877,0.24665 v 5.7205102 c 0,0.13661 0.04811,0.24659 0.107877,0.24659 h 2.521292 c 0.0598,0 0.107915,-0.10998 0.107915,-0.24659 V 5.2765948 c 0,-0.1366 -0.04812,-0.2466 -0.107915,-0.2466 h -2.521292 z"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93055552;stroke-linecap:round;stroke-linejoin:round"
+     id="path16414" />
+  <path
+     id="path16416"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.93055552;stroke-linecap:round;stroke-linejoin:round"
+     d="m 0.61759007,4.8629048 c -0.05976,0 -0.107877,0.11 -0.107877,0.24665 v 5.7205102 c 0,0.13661 0.04811,0.24658 0.107877,0.24658 H 3.1388821 c 0.0598,0 0.107915,-0.10997 0.107915,-0.24658 V 5.1095548 c 0,-0.1366 -0.04812,-0.2466 -0.107915,-0.2466 H 0.61759007 Z" />
+  <rect
+     style="opacity:0.98999999;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.09470218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect16418"
+     width="2.5720332"
+     height="1.5502055"
+     x="0.070509419"
+     y="-10.44966"
+     transform="rotate(90)"
+     ry="0.77510273" />
+</svg>

--- a/src/img/user-icon.svg
+++ b/src/img/user-icon.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xml:space="preserve"
+   enable-background="new 0 0 50 50"
+   viewBox="0 0 18.375999 18.546"
+   height="18.546"
+   width="18.375999"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata13"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs11" />
+<path
+   style="stroke:#000000;stroke-miterlimit:10"
+   id="path2"
+   d="m 17.876,9.358 c 0,4.799 -3.89,8.688 -8.688,8.688 v 0 C 4.39,18.046 0.5,14.157 0.5,9.358 V 9.188 C 0.5,4.389 4.39,0.5 9.188,0.5 v 0 c 4.799,0 8.688,3.89 8.688,8.688 z"
+   stroke-miterlimit="10" />
+<path
+   style="fill:#ffffff;stroke:#ffffff;stroke-miterlimit:10"
+   id="path4"
+   d="m 11.444,6.234 c 0,1.246 -1.011,2.258 -2.257,2.258 v 0 C 7.94,8.492 6.93,7.48 6.93,6.234 V 5.978 c 0,-1.246 1.01,-2.257 2.257,-2.257 v 0 c 1.246,0 2.257,1.011 2.257,2.257 z"
+   stroke-miterlimit="10" />
+<path
+   style="fill:#ffffff;stroke:#ffffff;stroke-miterlimit:10"
+   id="path6"
+   d="m 13.617,13.644 c 0,0 0.494,0 -4.43,0 -1.602,0 -4.429,0.134 -4.429,0 0,-2.657 1.983,-4.812 4.429,-4.812 2.448,0 4.43,2.155 4.43,4.812 z"
+   stroke-miterlimit="10" />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -5,9 +5,13 @@
     <script src="vendor/xhr-xdr-adapter.js" type="text/javascript"></script>
     <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE; chrome=1" />
     <meta charset="utf-8">
+    <!--
     <meta name="viewport" content="width=device-width">
+    -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 
     <title>Co-inform Dashboards</title>
+    <link rel="icon" href="https://coinform.eu/wp-content/uploads/2018/11/CO_INFORM_SYMBOL_PURPLE_LI_TW-150x150.jpg" sizes="32x32" />
     <link rel="stylesheet" href="css/bootstrap.light.min.css" title="Light">
     <link rel="stylesheet" href="css/timepicker.css">
     <link rel="stylesheet" href="css/animate.min.css">
@@ -25,19 +29,21 @@
     <!-- Hotjar Tracking Code for dashboard.coinform.eu -->
     <script>
      (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:1828450,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+         h._hjSettings={hjid:1828450,hjsv:6};
+         a=o.getElementsByTagName('head')[0];
+         r=o.createElement('script');r.async=1;
+         r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+         a.appendChild(r);
      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
     </script>
+
+    <script src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   </head>
 
   <body ng-cloak>
 
-    <link rel="stylesheet" ng-href="css/bootstrap.{{dashboard.current.style||'dark'}}.min.css">
+    <link rel="stylesheet" ng-href="css/bootstrap.{{dashboard.current.style||'ci'}}.min.css">
     <link rel="stylesheet" href="css/bootstrap-responsive.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">
 
@@ -57,11 +63,91 @@
         </div>
       </div>
     </div>
-    <div class="container-fluid main">
+    <div id="mySidebar" class="sidebar" ng-show="dashboard.current.sideColumn.panels.length > 0">
+      <span class="closebtn" title="Hide sidebar" onclick="closeNav()">
+        <i class="icon-remove"></i>
+      </span>
+      <!--
+      <a href="javascript:void(0)" class="closebtn" title="Hide sidebar" onclick="closeNav()">×</a>
+      -->
+      &nbsp;
+      <div class="sidebar-filters" ng-controller='SideColumnCtrl' ng-init="init()">
+        <!-- TODO: honor span? -->
+        <div ng-repeat="(name, panel) in dashboard.current.sideColumn.panels|filter:isPanel"
+             ng-hide="panel.span == 0 || panel.hide"
+             class="row-fluid panel"
+             style="min-width:{{dashboard.current.sideColumn.width}}; position:relative">
+          <!-- Error Panel -->
+          <div class="row-fluid">
+            <div class="span12 alert alert-error panel-error" ng-hide="!panel.error">
+              <a class="close" ng-click="panel.error=false">&times;</a>
+              <i class="icon-exclamation-sign"></i> <strong>Oops!</strong> {{panel.error}}
+            </div>
+          </div>
+          <!-- Content Panel -->
+          <div class="row-fluid">
+            <kibana-panel type="panel.type" ng-cloak></kibana-panel>
+          </div>          
+        </div>
+      </div>
+    </div>
+    <button class="openbtn" onclick="openNav()" title="Open sidebar"
+            ng-show="dashboard.current.sideColumn.panels.length > 0">☰</button>  
+    <div id="main" class="container-fluid main">
       <div class="row-fluid">
         <div ng-view></div>
       </div>
     </div>
+
+    <div class="main-footer">
+      <div class="main-footer-inner"'>
+        Built for Co-inform by Expert System Iberia <span style="font-weight: normal; vertical-align: middle; font-size: 14px;"><em>Copyright 2019<br></em><a href="https://coinform.eu/disclaimer/"><span style="color: #eaeaea;">Disclaimer</span></a></span>
+      </div>
+      <div class="social-media">
+				<ul class="" style="float:right;margin:0 0 22px;" data-animation-style="slide" data-animation-repeat="" data-animation-duration="1000ms" data-animation-delay="0ms" data-animation-intensity="50%" data-animation-starting-opacity="0%" data-animation-speed-curve="ease-in-out">
+				  <li class="social-media-follow">
+            <a href="https://www.facebook.com/Coinform" class="icon-facebook" title="Follow on Facebook" target="_blank">
+              <span class="" style="display: none" aria-hidden="true">Follow</span></a></li>
+          <li class="social-media-follow">
+            <a href="https://twitter.com/Co_Inform" class="icon-twitter" title="Follow on Twitter" target="_blank">
+              <span class="" style="display: none" aria-hidden="true">Follow</span></a></li>
+          <li class="social-media-follow">
+            <a href="https://www.linkedin.com/company/coinform/" class="icon-linkedin" title="Follow on LinkedIn" target="_blank">
+              <span class="" style="display: none" aria-hidden="true">Follow</span></a></li>
+			  </ul> <!-- .et_pb_counters -->
+			</div>
+    </div>
+
+    <div class="main-footer-funding">
+      <div class="funding-divider"></div>
+      <div class="funding-inner">
+        <div class="ec-logos">
+				  <div class="" style="" data-animation-style="slide" data-animation-repeat="" data-animation-duration="1000ms" data-animation-delay="0ms" data-animation-intensity="50%" data-animation-starting-opacity="0%" data-animation-speed-curve="ease-in-out">
+				    <span class="image_wrap "><img src="https://coinform.eu/wp-content/uploads/2018/06/EC-H2020.png"></span>
+			    </div>
+			  </div>
+        <div class="funding-text">
+				  <div class="" style="" data-animation-style="slide" data-animation-repeat="" data-animation-duration="1000ms" data-animation-delay="0ms" data-animation-intensity="50%" data-animation-starting-opacity="0%" data-animation-speed-curve="ease-in-out">
+				    <div class=""><p>Co-inform project is co-funded by Horizon 2020  the Framework Programme for Research and Innovation (2014-2020)<br>H2020-SC6-CO-CREATION-2016-2017 (CO-CREATION FOR GROWTH AND INCLUSION)<br>Type of action: RIA (Research and Innovation action)<br>Proposal number: 770302</p></div>
+			    </div> 
+			  </div>
+      </div>
+      <div ></div>
+    </div>
+    
+    <script>
+     function openNav() {
+         document.getElementById("mySidebar").style.width = "250px";
+         document.getElementById("main").style.marginLeft = "250px";
+     }
+
+     function closeNav() {
+         document.getElementById("mySidebar").style.width = "0";
+         document.getElementById("main").style.marginLeft= "0";
+     }
+    </script>
+    
   </body>
 
+  
 </html>


### PR DESCRIPTION
The table panel now has a custom default view called "Doc+Review"
which displays the document and its credibility review as "cards". The
document type is used so that tweets are displayed as embedded tweets
using the official Twitter widget. For documents which are not tweet,
we have a custom card.

Credibility reviews (or at least the main values encoded in documents)
returned by the back-end are also displayed as a card.

Banana does not support sidebars by default. This is problematic
because filters which affect the whole dashboard would be much better
displayed in such a sidebar. This commit implements an experimental
sidebar. The idea is that it's similar to a row in the normal
dashboard; however at the moment drag-and-drop doesn't work so panels
need to be added "programmatically" (by editing the json config
manually).

Fixed bug in heatmap: when clicking on a cell when axis are
transposed, the resulting filters were swapped.

Added footer and improvements to the standard co-inform css theme.